### PR TITLE
Increased the bufferSize, disabled update check in portable mode and fixed an app crash 

### DIFF
--- a/WinHasher/MainForm.cs
+++ b/WinHasher/MainForm.cs
@@ -307,7 +307,7 @@ namespace com.gpfcomics.WinHasher
             // should occur in a separate thread, which will allow the main UI thread to
             // continue without any problems.  The entire process *should* be transparent to
             // the user unless an update is actually found.
-            if (!disableUpdateCheck)
+            if (!portable && !disableUpdateCheck)
             {
                 try
                 {

--- a/WinHasher/Program.cs
+++ b/WinHasher/Program.cs
@@ -165,6 +165,10 @@ namespace com.gpfcomics.WinHasher
                     string[] args2 = new string[args.Length - 1];
                     Array.Copy(args, 1, args2, 0, args.Length - 1);
                     args = args2;
+
+                    //If there are no more arguments left, exit the loop
+                    if (args.Length == 0)
+                        break;
                 }
                 // By now, all our switches should be exhausted.  We should only have strings
                 // not starting with hyphens, which we'll interpret as file path strings.

--- a/WinHasherCore/HashEngine.cs
+++ b/WinHasherCore/HashEngine.cs
@@ -170,7 +170,7 @@ namespace com.gpfcomics.WinHasher.Core
         /// The buffer size for file reads.  Adjust this value if it is found to be too
         /// inefficient.
         /// </summary>
-        private static int bufferSize = 1024;
+        private static int bufferSize = 1024 * 1024;
 
         /// <summary>
         /// The default hash algorithm used by the HashEngine if no other hash has been specified.


### PR DESCRIPTION
I increased the bufferSize to 1MB to increase the speed by about 10x.
Fixed a crash when the program was called with invalid command line arguements.
I also disabled the update check on program start in portable mode.
